### PR TITLE
Add missing attributes for the RotatedRect interface

### DIFF
--- a/src/core/RotatedRect.d.ts
+++ b/src/core/RotatedRect.d.ts
@@ -11,6 +11,9 @@ declare module RotatedRect {
         points(pts: Point[]): void;
         boundingRect(): Rect;
         boundingRect2f(): Rect;
+        angle: number;
+        center: Point;
+        size: Size;
     }
 }
 export = RotatedRect;


### PR DESCRIPTION
This PR added the following attributes to the `RotatedRect` interface as per [cv::RotatedRect class reference](https://docs.opencv.org/4.5.3/db/dd6/classcv_1_1RotatedRect.html):

```ts
interface RotatedRect {
    angle: number;
    center: Point;
    size: Size;
}
```