### PR TITLE
Fix the type of `array` parameter in `matFromArray` method

### DIFF
--- a/src/opencv.d.ts
+++ b/src/opencv.d.ts
@@ -226,7 +226,7 @@ declare module opencv {
          * @param type data type of the Mat.
          * @param array source data array.
          */
-        matFromArray(rows: number, cols: number, type: DataTypes, array: Uint8Array): Mat;
+        matFromArray(rows: number, cols: number, type: DataTypes, array: number[]): Mat;
 
         /**
          * Function called when opencv is initialized


### PR DESCRIPTION
The `array` parameter should be annotated as `number[]` as we can construct Mat types besides `CV_8UC1`.