### PR TITLE
Add vconcat and hconcat

### DIFF
--- a/src/opencv.d.ts
+++ b/src/opencv.d.ts
@@ -784,6 +784,7 @@ declare module opencv {
             flags: GemmFlags
         ): void;
         getOptimalDFTSize(vecsize: number): number;
+        hconcat(srcs: MatVector, dst: Mat): void;
         hconcat(src: Mat, nsrc: number, dst: number): void;
         hconcat(src1: Mat, src2: Mat, dst: Mat): void;
         hconcat(src: Mat, dst: Mat, flags: DftFlags): void;
@@ -902,6 +903,7 @@ declare module opencv {
         trace(mtx: Mat): Scalar;
         transform(src: Mat, dst: Mat, m: Mat | MatVector): void;
         transpose(src: Mat, dst: Mat): void;
+        vconcat(srcs: MatVector, dst: Mat): void;
         vconcat(src: Mat, nsrc: number, dst: Mat): void;
         vconcat(src1: Mat, src2: Mat, dst: Mat): void;
         vconcat(src: Mat, dst: Mat): void;


### PR DESCRIPTION
These methods below represent the calls with the "InputArrayOfArrays" parameter similar to the c++ calls.

cv.hconcat(srcs: MatVector, dst: Mat): void;
cv.vconcat(srcs: MatVector, dst: Mat): void;


Support documentation:
https://docs.opencv.org/4.x/d2/de8/group__core__array.html#ga4676b1376cdc4e528dab6bd9edc51c1a

https://docs.opencv.org/4.x/d2/de8/group__core__array.html#ga558e169e15adcc46b8cdcc6cd215070f