### PR TITLE
Update type for optional parameters

### DIFF
--- a/src/opencv.d.ts
+++ b/src/opencv.d.ts
@@ -1686,7 +1686,7 @@ declare module opencv {
             templ: Mat,
             result: Mat,
             method: TemplateMatchModes,
-            mask: Mat
+            mask?: Mat
         ): void;
         groupRectangles(rectList: NDArray<Rect>, weights: MatVector, groupThreshold: number): void;
         TM_SQDIFF: TemplateMatchModes.TM_SQDIFF;

--- a/src/opencv.d.ts
+++ b/src/opencv.d.ts
@@ -878,7 +878,7 @@ declare module opencv {
             dst: Mat,
             dim: number,
             rtype: ReduceTypes,
-            dtype: number | DataTypes
+            dtype?: number | DataTypes
         ): void;
         repeat(src: Mat, ny: number, nx: number, dst: Mat): void;
         repeat(src: Mat, ny: number, nx: number): Mat;


### PR DESCRIPTION
Some functions have optional parameters but they are not properly defined in this package. Updated types to reflect this behavior.
[cv.matchTemplate](https://docs.opencv.org/4.x/df/dfb/group__imgproc__object.html#ga586ebfb0a7fb604b35a23d85391329be) has optional parameters 
[cv.reduce](https://docs.opencv.org/4.x/d2/de8/group__core__array.html#ga4b78072a303f29d9031d56e5638da78e) has optional parameters