### PR TITLE
findContours only accept MatVector

### DIFF
--- a/src/opencv.d.ts
+++ b/src/opencv.d.ts
@@ -1540,7 +1540,7 @@ declare module opencv {
         convexityDefects(contour: Mat, convexHull: Mat, convexityDefects: Mat): void;
         findContours(
             image: Mat | MatVector,
-            contours: Mat | MatVector,
+            contours: MatVector,
             hierarchy: Mat | MatVector,
             mode: RetrievalModes,
             method: ContourApproximationModes


### PR DESCRIPTION
I tested with Mat and receive fallow message error "Expected null or instance of MatVector"

I fixed according docs
https://docs.opencv.org/4.x/d3/dc0/group__imgproc__shape.html#gadf1ad6a0b82947fa1fe3c3d497f260e0