### PR TITLE
Add types for cv.exceptionFromPtr

### DIFF
--- a/src/opencv.d.ts
+++ b/src/opencv.d.ts
@@ -1751,6 +1751,7 @@ declare module opencv {
         OPTFLOW_LK_GET_MIN_EIGENVALS: Optflow.OPTFLOW_LK_GET_MIN_EIGENVALS;
         OPTFLOW_FARNEBACK_GAUSSIAN: Optflow.OPTFLOW_FARNEBACK_GAUSSIAN;
         rotatedRectPoints(points: RotatedRect): Point[];
+        exceptionFromPtr(pointer: number): { code: number, msg: string };
     }
 }
 


### PR DESCRIPTION
OpenCV.js can throw pointers to internal exceptions. By itself such a pointer is completely useless as no other contextual information is included. Luckily the library supports retrieving the exception behind a pointer using the `exceptionFromPtr` function.
This PR adds types for this function.